### PR TITLE
deploy: bump slate-cbl version to v3.0.0-beta.35; add load-cbl-branch studio command

### DIFF
--- a/.holo/sources/slate-cbl.toml
+++ b/.holo/sources/slate-cbl.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate-cbl"
-ref = "refs/tags/v3.0.0-beta.34"
+ref = "refs/tags/v3.0.0-beta.35"

--- a/.studiorc
+++ b/.studiorc
@@ -42,3 +42,5 @@ load-test-database() {
         git cat-file -p "${sql_tree}/${sql_file}"
     done | load-sql -
 }
+
+echo

--- a/.studiorc
+++ b/.studiorc
@@ -15,13 +15,13 @@ load-cbl-branch() {
     echo
     echo "--> Rebuilding and loading site..."
     HOLO_SOURCE_SLATE_CBL="#refs/heads/${branch_name}" \
-    HOLO_FETCH="slate-cbl" \
+    HOLO_FETCH="*" \
         update-site
 
     echo
     echo "--> Rebuilding test environment and reloading database..."
     HOLO_SOURCE_SLATE_CBL="#refs/heads/${branch_name}" \
-    HOLO_FETCH="slate-cbl" \
+    HOLO_FETCH="*" \
         load-test-database
 
     echo

--- a/.studiorc
+++ b/.studiorc
@@ -12,7 +12,33 @@ load-cbl-branch() {
     branch_name="${1}"
     [ -z "${branch_name}" ] && { echo >&2 'Usage: load-cbl-branch <branch-name>'; return 1; }
 
+    echo
+    echo "--> Rebuilding and loading site..."
     HOLO_SOURCE_SLATE_CBL="#refs/heads/${branch_name}" \
     HOLO_FETCH="slate-cbl" \
         update-site
+
+    echo
+    echo "--> Rebuilding test environment and reloading database..."
+    HOLO_SOURCE_SLATE_CBL="#refs/heads/${branch_name}" \
+    HOLO_FETCH="slate-cbl" \
+        load-test-database
+
+    echo
+    echo "--> Running all migrations..."
+    hab pkg exec emergence/php-runtime emergence-console-run migrations:execute --all
+
+    echo
+    echo " --> Branch '${branch_name}' loaded and ready to try!"
+}
+
+echo "    * Use 'load-test-database' to reset database to current test data"
+load-test-database() {
+    sql_tree="$(git holo project cypress-workspace):cypress/fixtures/database"
+
+    reset-mysql
+
+    for sql_file in $(git ls-tree --name-only "${sql_tree}"); do
+        git cat-file -p "${sql_tree}/${sql_file}"
+    done | load-sql -
 }


### PR DESCRIPTION
- feat: add load-test-database studio command and extend load-cbl-branch to use it automatically
- fix: update ALL sources when running load-cbl-branch
- chore: bump slate-cbl version to v3.0.0-beta.35
- style: add final blank line to studio output