### PR TITLE
deploy: bump slate-cbl version to v3.0.0-beta.36

### DIFF
--- a/.holo/sources/slate-cbl.toml
+++ b/.holo/sources/slate-cbl.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate-cbl"
-ref = "refs/tags/v3.0.0-beta.35"
+ref = "refs/tags/v3.0.0-beta.36"


### PR DESCRIPTION
- chore: bump slate-cbl to v3.0.0-beta.36