### PR TITLE
Release v1.0.0-rc.3

### DIFF
--- a/.holo/sources/slate-network-site.toml
+++ b/.holo/sources/slate-network-site.toml
@@ -1,6 +1,6 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate-network-site"
-ref = "refs/tags/v0.0.1-beta"
+ref = "refs/tags/v0.0.1-rc.1"
 
 [holosource.project]
 holobranch = "emergence-layer"


### PR DESCRIPTION
- chore: bump slate-network-site version
  - v0.0.1-rc.1