### PR TITLE
Release v1.0.0-rc.4

### DIFF
--- a/.holo/sources/slate-cbl.toml
+++ b/.holo/sources/slate-cbl.toml
@@ -1,3 +1,3 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate-cbl"
-ref = "refs/tags/v3.0.0-rc.1"
+ref = "refs/tags/v3.0.0-rc.2"

--- a/.holo/sources/slate-network-site.toml
+++ b/.holo/sources/slate-network-site.toml
@@ -1,6 +1,6 @@
 [holosource]
 url = "https://github.com/SlateFoundation/slate-network-site"
-ref = "refs/tags/v0.0.1-beta"
+ref = "refs/tags/v0.0.1-rc.1"
 
 [holosource.project]
 holobranch = "emergence-layer"


### PR DESCRIPTION
## Improvements

- fix: consistently exclude OLD competencies #30
- chore: bump slate-cbl to v3.0.0-rc.2