### PR TITLE
refactor: rename slate/terms export to b21/learningcycle

### DIFF
--- a/data-exporters/b21/learningcycle.php
+++ b/data-exporters/b21/learningcycle.php
@@ -3,9 +3,9 @@
 use Slate\Term;
 
 return [
-    'title' => 'Slate Terms',
+    'title' => 'Learning Cycle',
     'description' => 'Each row represents a term',
-    'filename' => 'slate-terms',
+    'filename' => 'learningcycle',
     'headers' => [
         'StartDate' => 'Start Date',
         'EndDate' => 'End Date',

--- a/php-classes/Slate/Connectors/DataWarehouse/Connector.php
+++ b/php-classes/Slate/Connectors/DataWarehouse/Connector.php
@@ -81,7 +81,7 @@ class Connector extends \Emergence\Connectors\AbstractConnector implements \Emer
                 'SkillCodes' => 'skillscodes'
             ]
         ],
-        'slate/terms' => [
+        'b21/learningcycle' => [
             'table' => 'learningcycle',
             'query' => [
                 'master-term' => 'current-master'


### PR DESCRIPTION
As I tried to merge slate/terms upstream to Slate, I realized it was too highly specialized for parsing B21 conventional term titles for a B21 data warehouse export.

A generic slate/terms exporter has been merged upstream, and this b21-specialized exporter is being renamed to reflect that